### PR TITLE
Move examples to additional jobs

### DIFF
--- a/upm/Dockerfile.all
+++ b/upm/Dockerfile.all
@@ -51,6 +51,8 @@ RUN cd /opt/mraa && \
     -DBUILDSWIGPYTHON=ON \
     -DBUILDSWIGNODE=ON \
     -DBUILDSWIGJAVA=ON \
+    -DIMRAA=ON \
+    -DFIRMATA=ON \
     -Bbuild \
     -H. && \
   make -Cbuild install && \

--- a/upm/Dockerfile.android
+++ b/upm/Dockerfile.android
@@ -59,6 +59,8 @@ RUN cd /opt/mraa && \
       -DBUILDSWIGPYTHON=OFF \
       -DBUILDSWIGNODE=OFF \
       -DBUILDSWIGJAVA=ON \
+      -DIMRAA=ON \
+      -DFIRMATA=ON \
       -H. \
       -Bbuild && \
     make -j8 -Cbuild install

--- a/upm/Dockerfile.android
+++ b/upm/Dockerfile.android
@@ -59,8 +59,6 @@ RUN cd /opt/mraa && \
       -DBUILDSWIGPYTHON=OFF \
       -DBUILDSWIGNODE=OFF \
       -DBUILDSWIGJAVA=ON \
-      -DIMRAA=ON \
-      -DFIRMATA=ON \
       -H. \
       -Bbuild && \
     make -j8 -Cbuild install

--- a/upm/Dockerfile.base
+++ b/upm/Dockerfile.base
@@ -72,6 +72,8 @@ RUN git clone https://github.com/intel-iot-devkit/mraa.git && \
   cd mraa && \
   cmake \
     -DCMAKE_INSTALL_PREFIX=install \
+    -DIMRAA=ON \
+    -DFIRMATA=ON \
     -DBUILDSWIG=OFF \
     -Bbuild \
     -H. && \

--- a/upm/Dockerfile.java
+++ b/upm/Dockerfile.java
@@ -17,6 +17,8 @@ RUN cd /opt/mraa && \
     -DBUILDSWIGPYTHON=OFF \
     -DBUILDSWIGNODE=OFF \
     -DBUILDSWIGJAVA=ON \
+    -DIMRAA=ON \
+    -DFIRMATA=ON \
     -Bbuild \
     -H. && \
   make -Cbuild install && \


### PR DESCRIPTION
The version of mraa that is shipped with the image was not built for imraa and firmata, which cause that upm disable some of it's functionality due to the lack of mraa support.

This changes enable imraa and firmata for the internal mraa version, fixing the situation described above.